### PR TITLE
Fix crash when a non-user (like a bot) send a message like the server

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -119,6 +119,7 @@ class GlobalBindings {
 
         // Handle messages
         client.on('message', (sender, message, users, channels, trees) => {
+          sender = sender || { __ui: 'Server' }
           ui.log.push({
             type: 'chat-message',
             user: sender.__ui,


### PR DESCRIPTION
Hello

I have a bot who spawn a message to a new user on the server and when this user receive the message, the app crash with this error in the console log : 

```
Connecting to server  mumble.xxx.net/web/mumble
Unhandled data packet: {name: "Version", payload: Message}
Unhandled data packet: {name: "CryptSetup", payload: Message}
Unhandled data packet: {name: "CodecVersion", payload: Message}
Unhandled data packet: {name: "PermissionQuery", payload: Message}
Unhandled data packet: {name: "ServerConfig", payload: Message}
Connected!
Uncaught TypeError: Cannot read property '__ui' of undefined
    at MumbleClient.<anonymous> (index.js:273)
    at MumbleClient.EventEmitter.emit (index.js:3416)
    at MumbleClient._onTextMessage (index.js:10785)
    at MumbleClient._onData (index.js:10709)
    at ReaDuplexer.EventEmitter.emit (index.js:3408)
    at ReaDuplexer.<anonymous> (index.js:25243)
    at ReaDuplexer.EventEmitter.emit (index.js:3405)
    at emitReadable_ (index.js:24905)
    at emitReadable (index.js:24901)
    at readableAddChunk (index.js:24644)
```

The little line fix the problem (but I can't say if this is the good way to do it).