### PR TITLE
Add mumble tokens

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -41,9 +41,22 @@
                   <td><input id="port" type="text" data-bind="value: port" required></td>
                 </tr>
                 <tr data-bind="if: $root.config.connectDialog.token">
-                  <td>Token</td>
-                  <td><input id="token" type="text" data-bind="value: token"></td>
+                  <td>Tokens</td>
+                  <td>
+                      <input type="text" data-bind='value: tokenToAdd, valueUpdate: "afterkeydown"'>
+                  </td>
                 </tr>
+                <tr data-bind="if: $root.config.connectDialog.token">
+                      <td></td>
+		      <td>
+                        <button class="dialog-submit" type="button" data-bind="enable: selectedTokens().length > 0, click: removeSelectedTokens()">Remove</button>
+                        <button class="dialog-submit" type="button" data-bind="enable: tokenToAdd().length > 0, click: addToken()">Add</button>
+  		      </td>
+                </tr>
+		<tr data-bind="if: $root.config.connectDialog.token">
+		  <td></td>
+		  <td><select id="token" multiple="multiple" height="5" data-bind="options:tokens, selectedOptions:selectedTokens, valueUpdate: 'afterkeydown', event: { keypress: $root.config.connectDialog.deleteSelectedTokensKey}"></select></td>
+		</tr>
                 <tr data-bind="if: $root.config.connectDialog.username">
                   <td>Username</td>
                   <td><input id="username" type="text" data-bind="value: username" required></td>

--- a/app/index.html
+++ b/app/index.html
@@ -53,7 +53,7 @@
                         <button class="dialog-submit" type="button" data-bind="enable: tokenToAdd().length > 0, click: addToken()">Add</button>
   		      </td>
                 </tr>
-		<tr data-bind="if: $root.config.connectDialog.token">
+		<tr data-bind="if: $root.config.connectDialog.token, visible: tokens().length > 0">
 		  <td></td>
 		  <td><select id="token" multiple="multiple" height="5" data-bind="options:tokens, selectedOptions:selectedTokens"></select></td>
 		</tr>

--- a/app/index.html
+++ b/app/index.html
@@ -40,6 +40,14 @@
                   <td>Port</td>
                   <td><input id="port" type="text" data-bind="value: port" required></td>
                 </tr>
+                <tr data-bind="if: $root.config.connectDialog.username">
+                  <td>Username</td>
+                  <td><input id="username" type="text" data-bind="value: username" required></td>
+                </tr>
+                <tr data-bind="if: $root.config.connectDialog.password">
+                  <td>Password</td>
+                  <td><input id="password" type="password" data-bind="value: password"></td>
+                </tr>
                 <tr data-bind="if: $root.config.connectDialog.token">
                   <td>Tokens</td>
                   <td>
@@ -48,22 +56,14 @@
                 </tr>
                 <tr data-bind="if: $root.config.connectDialog.token">
                       <td></td>
-		      <td>
+                      <td>
                         <button class="dialog-submit" type="button" data-bind="enable: selectedTokens().length > 0, click: removeSelectedTokens()">Remove</button>
                         <button class="dialog-submit" type="button" data-bind="enable: tokenToAdd().length > 0, click: addToken()">Add</button>
-  		      </td>
+                     </td>
                 </tr>
-		<tr data-bind="if: $root.config.connectDialog.token, visible: tokens().length > 0">
-		  <td></td>
-		  <td><select id="token" multiple="multiple" height="5" data-bind="options:tokens, selectedOptions:selectedTokens"></select></td>
-		</tr>
-                <tr data-bind="if: $root.config.connectDialog.username">
-                  <td>Username</td>
-                  <td><input id="username" type="text" data-bind="value: username" required></td>
-                </tr>
-                <tr data-bind="if: $root.config.connectDialog.password">
-                  <td>Password</td>
-                  <td><input id="password" type="password" data-bind="value: password"></td>
+               <tr data-bind="if: $root.config.connectDialog.token, visible: tokens().length > 0">
+                <td></td>
+                  <td><select id="token" multiple="multiple" height="5" data-bind="options:tokens, selectedOptions:selectedTokens"></select></td>
                 </tr>
                 <tr data-bind="if: $root.config.connectDialog.channelName">
                   <td>Channel</td>

--- a/app/index.html
+++ b/app/index.html
@@ -55,7 +55,7 @@
                 </tr>
 		<tr data-bind="if: $root.config.connectDialog.token">
 		  <td></td>
-		  <td><select id="token" multiple="multiple" height="5" data-bind="options:tokens, selectedOptions:selectedTokens, valueUpdate: 'afterkeydown', event: { keypress: $root.config.connectDialog.deleteSelectedTokensKey}"></select></td>
+		  <td><select id="token" multiple="multiple" height="5" data-bind="options:tokens, selectedOptions:selectedTokens"></select></td>
 		</tr>
                 <tr data-bind="if: $root.config.connectDialog.username">
                   <td>Username</td>

--- a/app/index.js
+++ b/app/index.js
@@ -76,11 +76,10 @@ function ConnectDialog () {
 
   self.removeSelectedTokensKey = function(data, event) {
     if (event.keyCode == 46) {
-      sefl.removeSelectedTokens()
+      self.removeSelectedTokens()
     }
   }
   self.removeSelectedTokens = function() {
-    console.log("gogog")
       this.tokens.removeAll(this.selectedTokens())
       this.selectedTokens([])
   }

--- a/app/index.js
+++ b/app/index.js
@@ -362,7 +362,7 @@ class GlobalBindings {
       this.connector.connect(`wss://${host}:${port}`, {
         username: username,
         password: password,
-	tokens: tokens
+        tokens: tokens
       }).done(client => {
         log('Connected!')
 
@@ -378,12 +378,11 @@ class GlobalBindings {
 
         // Register all channels, recursively
 	  
-	if(channelName.indexOf("/") != 0) {
-	  channelName = "/"+channelName;
-	}
+        if(channelName.indexOf("/") != 0) {
+          channelName = "/"+channelName;
+        }
         const registerChannel = (channel, channelPath) => {
           this._newChannel(channel)
- 	  console.log(channelPath)
           if(channelPath === channelName) {
 		console.log(channel)
             client.self.setChannel(channel)

--- a/app/index.js
+++ b/app/index.js
@@ -923,6 +923,9 @@ window.onload = function () {
   if (queryParams.tokens) {
     ui.connectDialog.tokens(queryParams.tokens.split(","))
   }
+  if (queryParams.token) {
+    ui.connectDialog.token(queryParams.token.split(","))
+  }
   if (queryParams.username) {
     ui.connectDialog.username(queryParams.username)
   } else {

--- a/app/index.js
+++ b/app/index.js
@@ -376,8 +376,7 @@ class GlobalBindings {
         // Make sure we stay open if we're running as Matrix widget
         window.matrixWidget.setAlwaysOnScreen(true)
 
-        // Register all channels, recursively
-	  
+        // Register all channels, recursively 
         if(channelName.indexOf("/") != 0) {
           channelName = "/"+channelName;
         }
@@ -913,11 +912,12 @@ window.onload = function () {
   } else {
     useJoinDialog = false
   }
-  if (queryParams.tokens) {
-    ui.connectDialog.tokens(queryParams.tokens.split(","))
-  }
   if (queryParams.token) {
-    ui.connectDialog.tokens(queryParams.token.split(","))
+    var tokens = queryParams.token
+    if (!Array.isArray(tokens)) {
+      tokens = [tokens]
+    }
+    ui.connectDialog.tokens(tokens)
   }
   if (queryParams.username) {
     ui.connectDialog.username(queryParams.username)

--- a/app/index.js
+++ b/app/index.js
@@ -74,11 +74,6 @@ function ConnectDialog () {
     self.tokenToAdd("")
   }
 
-  self.removeSelectedTokensKey = function(data, event) {
-    if (event.keyCode == 46) {
-      self.removeSelectedTokens()
-    }
-  }
   self.removeSelectedTokens = function() {
       this.tokens.removeAll(this.selectedTokens())
       this.selectedTokens([])

--- a/app/index.js
+++ b/app/index.js
@@ -52,7 +52,9 @@ function ConnectDialog () {
   var self = this
   self.address = ko.observable('')
   self.port = ko.observable('')
-  self.token = ko.observable('')
+  self.tokenToAdd = ko.observable('')
+  self.selectedTokens = ko.observableArray([])
+  self.tokens = ko.observableArray([])
   self.username = ko.observable('')
   self.password = ko.observable('')
   self.channelName = ko.observable('')
@@ -62,7 +64,25 @@ function ConnectDialog () {
   self.hide = self.visible.bind(self.visible, false)
   self.connect = function () {
     self.hide()
-    ui.connect(self.username(), self.address(), self.port(), self.token(), self.password(), self.channelName())
+    ui.connect(self.username(), self.address(), self.port(), self.tokens(), self.password(), self.channelName())
+  }
+
+  self.addToken = function() {
+    if ((self.tokenToAdd() != "") && (self.tokens.indexOf(self.tokenToAdd()) < 0)) {
+      self.tokens.push(self.tokenToAdd())
+    }
+    self.tokenToAdd("")
+  }
+
+  self.removeSelectedTokensKey = function(data, event) {
+    if (event.keyCode == 46) {
+      sefl.removeSelectedTokens()
+    }
+  }
+  self.removeSelectedTokens = function() {
+    console.log("gogog")
+      this.tokens.removeAll(this.selectedTokens())
+      this.selectedTokens([])
   }
 }
 
@@ -332,7 +352,7 @@ class GlobalBindings {
       return '[' + new Date().toLocaleTimeString('en-US') + ']'
     }
 
-    this.connect = (username, host, port, token, password, channelName = "") => {
+    this.connect = (username, host, port, tokens = [], password, channelName = "") => {
       this.resetClient()
 
       this.remoteHost(host)
@@ -347,7 +367,8 @@ class GlobalBindings {
       // TODO: token
       this.connector.connect(`wss://${host}:${port}`, {
         username: username,
-        password: password
+        password: password,
+	tokens: tokens
       }).done(client => {
         log('Connected!')
 
@@ -364,7 +385,9 @@ class GlobalBindings {
         // Register all channels, recursively
         const registerChannel = (channel, channelPath) => {
           this._newChannel(channel)
+ 	  console.log(channelPath)
           if(channelPath === channelName) {
+		console.log(channel)
             client.self.setChannel(channel)
           }
           channel.children.forEach(ch => registerChannel(ch, channelPath+"/"+ch.name))
@@ -894,8 +917,8 @@ window.onload = function () {
   } else {
     useJoinDialog = false
   }
-  if (queryParams.token) {
-    ui.connectDialog.token(queryParams.token)
+  if (queryParams.tokens) {
+    ui.connectDialog.tokens(queryParams.tokens.split(","))
   }
   if (queryParams.username) {
     ui.connectDialog.username(queryParams.username)

--- a/app/index.js
+++ b/app/index.js
@@ -919,7 +919,7 @@ window.onload = function () {
     ui.connectDialog.tokens(queryParams.tokens.split(","))
   }
   if (queryParams.token) {
-    ui.connectDialog.token(queryParams.token.split(","))
+    ui.connectDialog.tokens(queryParams.token.split(","))
   }
   if (queryParams.username) {
     ui.connectDialog.username(queryParams.username)

--- a/app/index.js
+++ b/app/index.js
@@ -384,7 +384,6 @@ class GlobalBindings {
         const registerChannel = (channel, channelPath) => {
           this._newChannel(channel)
           if(channelPath === channelName) {
-		console.log(channel)
             client.self.setChannel(channel)
           }
           channel.children.forEach(ch => registerChannel(ch, channelPath+"/"+ch.name))

--- a/app/index.js
+++ b/app/index.js
@@ -382,6 +382,10 @@ class GlobalBindings {
         window.matrixWidget.setAlwaysOnScreen(true)
 
         // Register all channels, recursively
+	  
+	if(channelName.indexOf("/") != 0) {
+	  channelName = "/"+channelName;
+	}
         const registerChannel = (channel, channelPath) => {
           this._newChannel(channel)
  	  console.log(channelPath)

--- a/themes/MetroMumbleLight/main.scss
+++ b/themes/MetroMumbleLight/main.scss
@@ -444,7 +444,7 @@ form {
   top: calc(50% - 10px);
   left: calc(50% - 100px);
 }
-.connect-dialog input[type=text] {
+.connect-dialog input[type=text], select {
   font-size: 15px;
   border: 1px $dialog-input-border-color solid;
   border-radius: 3px;


### PR DESCRIPTION
This adds mumble tokens for channel authentication (should close #63 )
A demo is available here: https://mumble.gattini.ninja/?tokens=antani,test&channelName=Test

About tokens in query, bot **token** and **tokens** are handled.
Tokens are comma separated  (like: ?tokens=token1,token2,token3) but i see that comma is an allowed character in mumble tokens so this will not work with tokens containing this character. 
I'm open to improve that, advices are welcome.

Also a quick edit on channelName.
Previously was mandatory to have channelName starting with '/' now if it's not present it's added automatically.