### PR TITLE
[dev] Create an "easy mode" version for beginners

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -25,8 +25,53 @@
     </div>
     <div id="container" style="display: none" data-bind="visible: true,
                                                          css: { minimal: minimalView }">
+
+      <div class="dialog-overlay" data-bind="visible: connectDialog.visible() && config.defaults.easyMode">
+        <div class="startup-dialog dialog">
+          <div class="dialog-header" data-bind="text: connected() ? 'Connecté' : 'Préparation'"></div>
+          <form data-bind="submit: connectDialog.connect">
+             <!-- ko if: !connected() -->
+            <fieldset>
+              <legend>Rejoindre l'appel sur le salon <br/>"<span data-bind="text: connectDialog.channelName"></span>"</legend>
+                  <label data-bind="visible: !connectDialog.loading()">
+                    Quel est ton nom ?
+                    <input type="text" data-bind="textInput: connectDialog.username" required autofocus>
+                  </label>
+                  <div data-bind="visible: connectDialog.loading()">
+                    Connexion en tant que <span data-bind="text: connectDialog.username"></span>,
+                    merci de patienter ...
+                    <div class="small"><div class="loading-container">
+                      <div class="loading-circle"><div></div><div><div></div></div></div>
+                    </div></div>
+                  </div>
+              <input class="dialog-submit" type="submit" data-bind="{
+                value: !connected() && !connectDialog.loading() ? 'Participer' : 'Connexion...',
+                disable: !connectDialog.username() || connectDialog.loading()
+              }">
+            </fieldset>
+            <!-- /ko -->
+            <!-- ko if: connected() -->
+            <fieldset>
+              Bonjour <span data-bind="text: thisUser().name()"></span>,
+              te voilà connecté sur le salon <span data-bind="text: thisUser().channel().name()"></span>.
+              <!-- ko if: thisUser().channel() -->
+              <p>Il y a <span data-bind="text: thisUser().channel().users().length"></span> participants à ce salon</p>
+              <!-- /ko -->
+              <ul data-bind="foreach: thisUser().channel().users()" style="text-align: left">
+                <li>
+                  <span data-bind="{text: name, style: {fontWeight: name() == $parent.thisUser().name() ? 'bold': 'normal'}}"></span>
+                  <div data-bind="{class: talking, text: talking}" class="talking"></div>
+                </li>
+              </ul>
+              <button class="dialog-submit" data-bind="click: connectDialog.hide">Interface complète</button>
+            </fieldset>
+            <!-- /ko -->
+          </form>
+        </div>
+      </div>
+
       <!-- ko with: connectDialog --> 
-      <div class="connect-dialog dialog" data-bind="visible: visible() && !joinOnly()">
+      <div class="connect-dialog dialog" data-bind="visible: visible() && !joinOnly() && !config.defaults.easyMode">
           <div class="dialog-header">
             Connect to Server
           </div>

--- a/app/index.js
+++ b/app/index.js
@@ -60,10 +60,15 @@ function ConnectDialog () {
   self.channelName = ko.observable('')
   self.joinOnly = ko.observable(false)
   self.visible = ko.observable(true)
+  self.loading = ko.observable(false)
   self.show = self.visible.bind(self.visible, true)
   self.hide = self.visible.bind(self.visible, false)
   self.connect = function () {
-    self.hide()
+    self.loading(true)
+    if( !ui.config.defaults.easyMode) {
+      // hide the dialog when loading is done
+      self.loading.subscribe(loading => !loading ? self.hide() : null)
+    }
     ui.connect(self.username(), self.address(), self.port(), self.tokens(), self.password(), self.channelName())
   }
 
@@ -367,6 +372,7 @@ class GlobalBindings {
         log('Connected!')
 
         this.client = client
+        this.connectDialog.loading(false)
         // Prepare for connection errors
         client.on('error', (err) => {
           log('Connection error:', err)

--- a/themes/MetroMumbleLight/main.scss
+++ b/themes/MetroMumbleLight/main.scss
@@ -392,6 +392,16 @@ form {
   text-align: center;
   width: 100%
 }
+.dialog-overlay {
+  content: "";
+  position: absolute;
+  z-index: 19;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(238,238,238, 0.9);
+}
 .dialog {
   position: absolute;
   max-height: calc(100% - 20px);
@@ -405,6 +415,10 @@ form {
   border: 1px $dialog-border-color solid;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
   z-index: 20;
+}
+.startup-dialog {
+  width: 50%;
+  height: 50%;
 }
 .settings-dialog table {
   width: 100%;
@@ -443,6 +457,18 @@ form {
   position: absolute;
   top: calc(50% - 10px);
   left: calc(50% - 100px);
+}
+.startup-dialog .dialog-submit {
+  margin: auto;
+  float: none;
+  display: block;
+}
+.startup-dialog .dialog-submit:disabled {
+  color: #b9b9b9;
+}
+.startup-dialog fieldset {
+  padding: 1em;
+  margin: 2em;
 }
 .connect-dialog input[type=text], select {
   font-size: 15px;


### PR DESCRIPTION
Here is a first attempt to made the interface easier to use for people that don't know anything about mumble. When the page loads, the connection popup is replaced by a easier one that hide server, and port complexity (that should be provided by the configuration file) and ask only for the name.

Once the connection is up, the popup stay open and shows the list of people connected on the same channel as well as an indication about their respective voice status.