### PR TITLE
[dev] Add npm run watch command for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An HTML5 Mumble client.",
   "scripts": {
     "build": "webpack && [ -f dist/config.local.js ] || cp app/config.local.js dist/",
+    "watch": "webpack --watch",
     "prepare": "rm -rf dist && npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "patch-package"


### PR DESCRIPTION
watch mode in webpack is very usefull when developing : by using `npm run watch`, webpack monitor any file change and update the corresponding build files in no time.