### PR TITLE
[fix] Display permission denied error messages

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -408,6 +408,14 @@ class GlobalBindings {
           })
         })
 
+        // Log permission denied error messages
+        client.on('denied', (type) => {
+          ui.log.push({
+            type: 'generic',
+            value: 'Permission denied : '+ type
+          })
+        })
+
         // Set own user and root channel
         this.thisUser(client.self.__ui)
         this.root(client.root.__ui)

--- a/app/worker.js
+++ b/app/worker.js
@@ -187,6 +187,7 @@ import 'subworkers'
     id = { client: id }
 
     registerEventProxy(id, client, 'error')
+    registerEventProxy(id, client, 'denied', it => [it])
     registerEventProxy(id, client, 'newChannel', (it) => [setupChannel(id, it)])
     registerEventProxy(id, client, 'newUser', (it) => [setupUser(id, it)])
     registerEventProxy(id, client, 'message', (sender, message, users, channels, trees) => {


### PR DESCRIPTION
This change make `denied` events visible in the log window. This is useful when a channel is protected by a password : it shows the user why its join tentative has failed.