### PR TITLE
Automatic Reconnects

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -489,6 +489,10 @@ class GlobalBindings {
           log(translate('logentry.connection_error'), err)
           this.resetClient()
         })
+        client.on('disconnect', (err) => {
+          log(translate('logentry.connection_error'), err)
+          this.reconnect(username, host, port, tokens, password, channelName)
+        })
 
         // Make sure we stay open if we're running as Matrix widget
         window.matrixWidget.setAlwaysOnScreen(true)
@@ -565,6 +569,7 @@ class GlobalBindings {
           this.connect(username, host, port, tokens, password, channelName)
         } else {
           log(translate('logentry.connection_error'), err)
+          this.reconnect(username, host, port, tokens, password, channelName)
         }
       })
     }
@@ -824,6 +829,11 @@ class GlobalBindings {
       }
       this.client = null
       this.selected(null).root(null).thisUser(null)
+    }
+
+    this.reconnect = (username, host, port, tokens, password, channelName) => {
+      log("Connection Lost!\nReconnecting in 5 seconds!")
+      setTimeout(() => this.connect(username, host, port, tokens, password, channelName), 5000)
     }
 
     this.connected = () => this.thisUser() != null

--- a/app/worker-client.js
+++ b/app/worker-client.js
@@ -146,6 +146,7 @@ export class WorkerBasedMumbleClient extends EventEmitter {
     let _disconnect = this.disconnect
     this.disconnect = () => {
       _disconnect.apply(this)
+      this.emit('disconnect')
       delete connector._clients[id]
     }
 


### PR DESCRIPTION
Enables the client to automatically reconnect, when the connection to murmur hasn't been established, yet, or an established connection has been lost.
Requires this [PR](https://github.com/Johni0702/mumble-client/pull/6) to work properly.