### PR TITLE
Use AudioWorklet to record microphone input

### DIFF
--- a/app/recorder.js
+++ b/app/recorder.js
@@ -1,0 +1,16 @@
+class RecorderWorkletProcessor extends AudioWorkletProcessor {
+	process(inputs, outputs, parameters) {
+		if (this._number === undefined) {
+			this._number = 1
+		}
+
+		const timestamp = Date.now()
+		const buffer = new Uint8Array(inputs[0][0].buffer)
+		this.port.postMessage({ eventType: 'data', audioBuffer: buffer, timestamp: timestamp, number: this._number })
+		this._number++
+
+		return true
+	}
+}
+
+registerProcessor('recorder-worklet', RecorderWorkletProcessor)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "web-audio-buffer-queue": "^1.1.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
-    "worker-loader": "^2.0.0"
+    "worker-loader": "^2.0.0",
+    "worklet-loader": "^1.0.0"
   },
   "optionalDependencies": {}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,11 @@ module.exports = {
         use: { loader: 'worker-loader' }
       },
       {
+        test: /recorder\.js$/,
+        loader: 'worklet-loader',
+        options: {name:'[hash].audioworklet.js'}
+      },
+      {
         enforce: 'post',
         test: /mumble-streams\/lib\/data.js/,
         use: [


### PR DESCRIPTION
Replace old dependency using ScriptNode Processor with AudioWorklet to record microphone input. This is a solution for Issue #141.
- recorder.js contains the AudioWorklet and sends audio packets via postMessage
- voice.js loads AudioWorklet, receives audio packets of recorder.js and forwards them to the voice pipeline
- voice.js also discards voice packets that needed too long between the postMessage of recorder.js and the recorderNode.port.onMessage  in voice.js. This delay is hard-coded.
- package.json contains new dep to load AudioWorklet
- webpack.config.js includes AudioWorklet into the build process
