### PR TITLE
add `inlang` to make the contribution of translations easier

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,16 @@
+export async function defineConfig(env) {
+	const { default: pluginJson } = await env.$import(
+		'https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@2/dist/index.js'
+	);
+
+	const { default: standardLintRules } = await env.$import(
+		'https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@2/dist/index.js'
+	);
+
+	return {
+		referenceLanguage: 'en',
+		plugins: [pluginJson({ 
+			pathPattern: './loc/{language}.json'
+		}), standardLintRules()]
+	};
+}

--- a/loc/de.json
+++ b/loc/de.json
@@ -11,7 +11,10 @@
     "cancel": "Abbrechen",
     "connect": "Verbinden",
     "error": {
-      "title": "Verbindung nicht möglich"
+      "title": "Verbindung nicht möglich",
+      "reason": {
+        "refused": "Die Verbindung wurde abgelehnt."
+      }
     }
   }
 }

--- a/loc/de.json
+++ b/loc/de.json
@@ -9,7 +9,9 @@
     "remove": "Entfernen",
     "add": "Hinzufügen",
     "cancel": "Abbrechen",
-    "connect": "Verbinden"
+    "connect": "Verbinden",
+    "error": {
+      "title": "Verbindung nicht möglich"
+    }
   }
 }
-

--- a/loc/de.json
+++ b/loc/de.json
@@ -13,7 +13,8 @@
     "error": {
       "title": "Verbindung nicht möglich",
       "reason": {
-        "refused": "Die Verbindung wurde abgelehnt."
+        "refused": "Die Verbindung wurde abgelehnt.",
+        "version": "Der Server verwendet eine inkompatible Version."
       }
     }
   }

--- a/loc/en.json
+++ b/loc/en.json
@@ -88,4 +88,3 @@
     "user_message_placeholder": "Type message to user '%1' here"
   }
 }
-

--- a/loc/eo.json
+++ b/loc/eo.json
@@ -12,4 +12,3 @@
     "connect": "Konekti"
   }
 }
-

--- a/loc/es.json
+++ b/loc/es.json
@@ -74,4 +74,3 @@
     "user_message_placeholder": "Escribe un mensaje al usuario '%1'"
   }
 }
-

--- a/loc/oc.json
+++ b/loc/oc.json
@@ -61,7 +61,7 @@
     "copy_mumble_url": "Copair l’URL Mumble",
     "copy_mumble_web_url": "Copiar l’URL Mumble-Web",
     "send_message": "Enviar messatge"
- },
+  },
   "logentry": {
     "connecting": "Connexion al servidor",
     "connected": "Connectat !",
@@ -71,6 +71,6 @@
   },
   "chat": {
     "channel_message_placeholder": "Escrivètz un messatge per la sala '%1' aquí",
-    "user_message_placeholder": "Escrivètz un messatge a '%1' aquí"    
+    "user_message_placeholder": "Escrivètz un messatge a '%1' aquí"
   }
 }


### PR DESCRIPTION
Let me know what changes you request for merging this PR.

### Description
This pull request adds the possibility for contributors and translators to manage translations in a UI instead of files with no overhead for the maintainers.

To get a UI for translations contained in this repository, an [inlang.config.js](https://inlang.com/documentation/config) has been created at the root of the repository.

### Preview
The changes of this PR and a live instance of the editor can be previewed with the following link https://inlang.com/editor/github.com/NilsJacobsen/mumble-web. Note: This link should be changed to point to mumble-web instead of NilsJacobsen after this PR has been merged.

### Limitations
**Certain actions are slow**
Inlang is running entirely on git, giving tremendous CI/CD and contribution power to localization (and potentially other verticals -> [the next git](https://www.youtube.com/watch?v=vJ3jGgCrz2I)). That means that the whole mumble-web repo is cloned into the browser which makes certain actions like the initial load and pushing changes slow. Those limitations will be fixed with future releases and require no input from mumble-web.

![pika-1680686287719-1x](https://user-images.githubusercontent.com/58360188/232016041-ec0c3da3-94a9-4492-85dd-d8478c66d945.jpeg)

### Badge
If you want to show the contributor the status of the translations, you could add a badge to your readme.
```
[![translation badge](https://inlang.com/badge?url=github.com/Johni0702/mumble-web)](https://inlang.com/editor/github.com/Johni0702/mumble-web?ref=badge)
```

Preview the messages on https://inlang.com/github.com/NilsJacobsen/mumble-web .